### PR TITLE
feature: add tooling config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,12 @@
  * @license GPL-3.0-or-later
  */
 
-import './lib/featureCheck'; // warn user of missing feature support first
-import './components/mainMenu';
-import './components/digest';
-import './components/prng';
-import './components/encryption';
-import './components/passwords';
-import './lib/form';
-import './lib/operationAreas';
-import './lib/tabs';
+import '@/lib/featureCheck'; // warn user of missing feature support first
+import '@/components/mainMenu';
+import '@/components/digest';
+import '@/components/prng';
+import '@/components/encryption';
+import '@/components/passwords';
+import '@/lib/form';
+import '@/lib/operationAreas';
+import '@/lib/tabs';

--- a/src/package.json
+++ b/src/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node esbuild.mjs --watch",
     "build": "node esbuild.mjs",
-    "lint": "cd .. && npx eslint src"
+    "lint": "cd .. && npx eslint src",
+    "format": "cd .. && npx prettier --write src && npx eslint src --fix"
   },
   "author": "Micah Henning <hello@micah.soy>",
   "license": "GPL-3.0-or-later",

--- a/src/prettier.config.cjs
+++ b/src/prettier.config.cjs
@@ -1,0 +1,33 @@
+const overrides = [
+  {
+    files: ['*.yml', '*.yaml'],
+    options: {
+      tabWidth: 2,
+    },
+  },
+  {
+    files: 'tsconfig.json',
+    options: {
+      parser: 'json',
+    },
+  },
+];
+
+module.exports = {
+  arrowParens: 'avoid',
+  bracketSameLine: true,
+  bracketSpacing: true,
+  htmlWhitespaceSensitivity: 'css',
+  insertPragma: false,
+  jsxSingleQuote: false,
+  overrides,
+  printWidth: 160,
+  proseWrap: 'preserve',
+  quoteProps: 'as-needed',
+  requirePragma: false,
+  semi: true,
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'all',
+  useTabs: false,
+};

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ESNext",
     "strict": true,
     "noImplicitReturns": true,
     "removeComments": true,
@@ -13,7 +13,8 @@
     "rootDir": "./",
     "baseUrl": ".",
     "paths": {
-      "*": ["types/*"]
+      "*": ["types/*"],
+      "@/*": ["./*"]
     }
   },
   "include": [


### PR DESCRIPTION
This PR adds a more robust tooling configuration:

- opinionated prettier configuration
- adds npm script `format` for running `prettier` folowed by `eslint` for optimal formatting
- changes the typescript target to `ESNext` (it's 2024, commonJS is _so_ 2023)
- adds `@` as a typescript path reference to allow for absolute imports within source files
- demonstrates the use of `import * from @/...` in one typescript file to start 